### PR TITLE
Support logstash 5

### DIFF
--- a/lib/logstash/outputs/firehose.rb
+++ b/lib/logstash/outputs/firehose.rb
@@ -45,8 +45,6 @@ class LogStash::Outputs::Firehose < LogStash::Outputs::Base
 
   # make properties visible for tests
   attr_accessor :stream
-  attr_accessor :access_key_id
-  attr_accessor :secret_access_key
   attr_accessor :codec
 
   config_name "firehose"
@@ -57,8 +55,6 @@ class LogStash::Outputs::Firehose < LogStash::Outputs::Base
   # Firehose stream info
   config :region, :validate => :string, :default => "us-east-1"
   config :stream, :validate => :string
-  config :access_key_id, :validate => :string
-  config :secret_access_key, :validate => :string
 
   #
   # Register plugin

--- a/logstash-output-firehose.gemspec
+++ b/logstash-output-firehose.gemspec
@@ -1,12 +1,12 @@
 Gem::Specification.new do |s|
-  s.name = 'logstash-output-firehose'
-  s.version         = "0.0.2"
-  s.licenses = ["Apache License (2.0)"]
-  s.summary = "Output plugin to push data into AWS Kinesis Firehose stream."
-  s.description = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
-  s.authors = ["Valera Chevtaev"]
-  s.email = "myltik@gmail.com"
-  s.homepage = "https://github.com/chupakabr/logstash-output-firehose"
+  s.name          = 'logstash-output-firehose'
+  s.version       = "0.0.2"
+  s.licenses      = ["Apache License (2.0)"]
+  s.summary       = "Output plugin to push data into AWS Kinesis Firehose stream."
+  s.description   = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
+  s.authors       = ["Valera Chevtaev"]
+  s.email         = "myltik@gmail.com"
+  s.homepage      = "https://github.com/chupakabr/logstash-output-firehose"
   s.require_paths = ["lib"]
 
   # Files

--- a/logstash-output-firehose.gemspec
+++ b/logstash-output-firehose.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "stud", "~> 0.0.22"
-  s.add_runtime_dependency "logstash-core", ">= 2.0.0", "< 3.0.0"
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency "logstash-mixin-aws", ">= 2.0.2"
   s.add_runtime_dependency "logstash-codec-line"
   s.add_runtime_dependency "logstash-codec-json_lines"

--- a/spec/outputs/firehose_spec.rb
+++ b/spec/outputs/firehose_spec.rb
@@ -19,8 +19,6 @@ describe LogStash::Outputs::Firehose do
 
     # Setup Firehose client
     output.stream = "aws-test-stream"
-    output.access_key_id = "Key ID"
-    output.secret_access_key = "Secret key"
     output.register
   end
 


### PR DESCRIPTION
This brings support for Logstash 5, but also allows a future PR (https://github.com/logstash-plugins/logstash-mixin-aws/pull/27) to work. It's not necessary to specify access_key_id and secret_key_id parameters as they are inherited from the aws-mixin